### PR TITLE
update batch with clean debug and release arguments

### DIFF
--- a/January/build.bat
+++ b/January/build.bat
@@ -2,9 +2,16 @@ REM Build script for testbed
 @ECHO OFF
 SetLocal EnableDelayedExpansion
 
+SET CONFIG=%1
+
+if "%CONFIG%" == "clean" goto clean
+if "%CONFIG%" == "release" goto build
+if "%CONFIG%" == "debug" goto build
+goto notdefined
+
+:build
 if not exist "%cd%\bin\" mkdir "%cd%\bin\"
-
-
+ 
 REM Get a list of all the .c files.
 SET cFilenames=
 FOR /R %%f in (*.c) do (
@@ -15,15 +22,34 @@ FOR /R %%f in (*.c) do (
 echo "Files:" %cFilenames%
 
 SET assembly=KayoPong
+if "%CONFIG%" == "debug" goto debug
 SET compilerFlags=-g
+SET defines=-D_DEBUG
+goto link
+:debug
+SET compilerFlags=-O2
+SET defines=-D_RELEASE
+
+:link
 SET includeFlags=-Isrc -I%SDL2%/include -I%SDL2_ttf%/include
 SET linkerFlags= -L%SDL2%/lib/x64 -L%SDL2_ttf%\lib\x64 -lSDL2 -lSDL2main -l:SDL2.dll -lSDL2_ttf -l:SDL2_ttf.dll
-SET defines=-D_DEBUG
+if not exist "%cd%\bin\%CONFIG%\" mkdir "%cd%\bin\%CONFIG%\"
 
 ECHO "Building %assembly%%..."
-gcc %cFilenames% %compilerFlags% -o ./bin/%assembly%.exe %defines% %includeFlags% %linkerFlags%
+gcc %cFilenames% %compilerFlags% -o ./bin/%CONFIG%\%assembly%.exe %defines% %includeFlags% %linkerFlags%
 
 ECHO "Copying DLL(s)..."
 copy /y "%SDL2%\lib\x64\SDL2.dll" /b ".\bin\%CONFIG%\"
 copy /y "%SDL2_ttf%\lib\x64\SDL2_ttf.dll" /b ".\bin\%CONFIG%\"
-xcopy "assets" "bin\assets" /h /i /c /k /e /r /y
+xcopy "assets" "bin\%CONFIG%\assets" /h /i /c /k /e /r /y
+goto end
+
+:clean
+ECHO "Cleaning..."
+if exist ".\bin\" rmdir /S /Q ".\bin\"
+goto end
+:notdefined
+ECHO "Config not defined, please add 'release' 'debug' or 'clean' to the command line when running ./build.bat."
+
+
+:end


### PR DESCRIPTION
added additional batch functionality to build.bat.

build.bat now requires an argument to build the arguments accepted are listed below.

clean - checks if .\bin exists, if it does all folders and files within
debug - builds KayoPong.exe to ./bin/debug/ with debug flags (-g) and defines -D_DEBUG
release - builds KayoPong.exe to ./bin/release with optimization flags (-O2) and defines -D_RELEASE